### PR TITLE
chore: Trigger PyPI release on GitHub release `published`, not `created`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build_deploy:


### PR DESCRIPTION
Using `created` doesn't work when the release is first created as a draft, because no tag is associated with it, so a dynamic version cannot be assigned.

Using `published` fixes that, by triggering the PyPI release _only_ when a tag is sure to exist.
