### PR TITLE
chore: pin GitHub Actions versions to commit hashes

### DIFF
--- a/.github/workflows/project_add.yml
+++ b/.github/workflows/project_add.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/MeltanoLabs/projects/3
           github-token: ${{ secrets.MELTYBOT_PROJECT_ADD_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         poetry dynamic-versioning --no-cache
         poetry build
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: dist/*.whl
@@ -40,4 +40,4 @@ jobs:
         overwrite: true
         file_glob: true
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/test-evidence.yml
+++ b/.github/workflows/test-evidence.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Meltano


### PR DESCRIPTION
This will help prevent attacks such as [this one](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/).

Dependabot is able to update these versions automatically, and it will preserve the readable version comments.
