### PR TITLE
fix: install missing degit dependency on init

### DIFF
--- a/evidence_ext/extension.py
+++ b/evidence_ext/extension.py
@@ -78,7 +78,10 @@ class Evidence(ExtensionBase):
             # force is needed here as installing degit creates the destination directory
             # and it's safe to overwrite it
             self._npx.run_and_log(
-                "degit", "--force", "evidence-dev/template", self.evidence_home
+                "degit",
+                "--force",
+                "evidence-dev/template",
+                self.evidence_home,
             )
         except subprocess.CalledProcessError as err:
             log_subprocess_error("npx degit", err, "npx degit failed")

--- a/evidence_ext/extension.py
+++ b/evidence_ext/extension.py
@@ -65,7 +65,21 @@ class Evidence(ExtensionBase):
             CalledProcessError: If the initialization fails.
         """
         try:
-            self._npx.run_and_log("degit", "evidence-dev/template", self.evidence_home)
+            command_args = (
+                "--prefix",
+                self.evidence_home,
+                "install",
+                "--quiet",
+                "--no-progress",
+                "--no-audit",
+                "degit",
+            )
+            self._npm.run_and_log(*command_args)
+            # force is needed here as installing degit creates the destination directory
+            # and it's safe to overwrite it
+            self._npx.run_and_log(
+                "degit", "--force", "evidence-dev/template", self.evidence_home
+            )
         except subprocess.CalledProcessError as err:
             log_subprocess_error("npx degit", err, "npx degit failed")
             sys.exit(err.returncode)


### PR DESCRIPTION
The current on-boarding experience for `evidence-ext` is broken. New projects running `meltano invoke evidence initialize` find the command hangs waiting on input, without any input prompt. Degit is required for scaffolding new evidence projects, but isn't installed. This PR installs `degit` quietly before it is called in `init`.